### PR TITLE
Add SSKG Hub (LLM-empowered sustainability standards KGs) to LLMs for Knowledge Graphs

### DIFF
--- a/topics/Knowledge Graph and LLMs.md
+++ b/topics/Knowledge Graph and LLMs.md
@@ -112,6 +112,8 @@ guide the search process.
 22. Language Models over Large-Scale Knowledge Base: on Capacity, Flexibility and Reasoning for New Facts (COLING 2025)
 23. Construction and Canonicalization of Economic Knowledge Graphs with LLMs (KGSWC 2024) [[Link](https://books.google.com.hk/books?hl=zh-CN&lr=&id=3yhGEQAAQBAJ&oi=fnd&pg=PA334&ots=KPSlLdVk8m&sig=HW4PzpubB902d1_dLgwv_UWpIGY&redir_esc=y#v=onepage&q&f=false)]
 24. Utilizing Language Models For Synthetic Knowledge Graph Generation (ICLR 2025 Workshop Data Problems) [[Paper](https://openreview.net/forum?id=IutH9tRtMI)]
+25. SSKG Hub: An Expert-Guided Platform for LLM-Empowered Sustainability Standards Knowledge Graphs (arXiv 2026) [[Paper](https://arxiv.org/abs/2603.00669)] [[Platform](https://www.sskg-hub.com/)]
+> * LLM extraction turns sustainability disclosure standards (GRI, SASB, TCFD, IFRS S2) into provenance-linked Draft KGs that domain experts review and promote to Certified KGs under role-based governance.
 25. Finetuning Generative Large Language Models with Discrimination Instructions for Knowledge Graph Completion (ISWC 2024) [[Paper](https://arxiv.org/pdf/2407.16127)]
 26. CypherBench: Towards Precise Retrieval over Full-scale Modern Knowledge Graphs in the LLM Era (ACL 2025)
 27. Generating Domain-Specific Knowledge Graphs from Large Language Models (ACL 2025)


### PR DESCRIPTION
Adds **"SSKG Hub: An Expert-Guided Platform for LLM-Empowered Sustainability Standards Knowledge Graphs"** (He et al., arXiv 2026) to **topics/Knowledge Graph and LLMs.md → LLMs for Knowledge Graphs**, next to the synthetic/domain KG-generation entries.

LLM extraction turns sustainability disclosure standards (GRI, SASB, TCFD, IFRS S2) into provenance-linked Draft KGs; domain experts review and promote them to Certified KGs under role-based governance (Neo4j storage). Live platform: https://www.sskg-hub.com/

Link: https://arxiv.org/abs/2603.00669

Anchored mid-section to avoid overlap with my open PRs #16/#17 (all merge cleanly). Disclosure: I am an author.